### PR TITLE
Don't create user and extensions when (re)starting

### DIFF
--- a/postgres-entry.sh
+++ b/postgres-entry.sh
@@ -2,9 +2,12 @@
 set -e
 
 if [ "$1" = 'postgres' ]; then
+  first_run=false
   chown -R postgres "$PGDATA"
 
   if [ -z "$(ls -A "$PGDATA")" ]; then
+    # This is the first time the container has been started
+    first_run=true
     gosu postgres initdb
 
     # Enable access for all hosts. This is okay for a docker container.
@@ -14,20 +17,22 @@ if [ "$1" = 'postgres' ]; then
     sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf
   fi
 
-  echo "Starting Postgres and creating OSM database"
-  gosu postgres pg_ctl -w start
-  gosu postgres createuser "$OSM_USER"
-  gosu postgres createdb -E UTF8 -O "$OSM_USER" "$OSM_DB"
-  gosu postgres psql "$OSM_DB" <<EOF
-  CREATE EXTENSION postgis;
-  CREATE EXTENSION hstore;
-  ALTER TABLE geometry_columns OWNER TO "${OSM_USER}";
-  ALTER TABLE spatial_ref_sys OWNER TO "${OSM_USER}";
+  if [[ "$first_run" = true ]]; then
+    echo "Starting Postgres and creating OSM database"
+    gosu postgres pg_ctl -w start
+    gosu postgres createuser "$OSM_USER"
+    gosu postgres createdb -E UTF8 -O "$OSM_USER" "$OSM_DB"
+    gosu postgres psql "$OSM_DB" <<EOF
+    CREATE EXTENSION postgis;
+    CREATE EXTENSION hstore;
+    ALTER TABLE geometry_columns OWNER TO "${OSM_USER}";
+    ALTER TABLE spatial_ref_sys OWNER TO "${OSM_USER}";
 EOF
 
-  # Run the server in the foreground
-  echo "Done init for OSM. One final restart."
-  gosu postgres pg_ctl stop
+    # Run the server in the foreground
+    echo "Done init for OSM. One final restart."
+    gosu postgres pg_ctl stop
+  fi
   exec gosu postgres "$@"
 fi
 


### PR DESCRIPTION
When restarting a container with

docker stop postgres-osm
docker start postgres-osm

the entry script executes the user and extension creation
all over again which leads to the following error:

createuser: creation of new role failed: ERROR:  role "osm" already exists

This means that once a container has been stopped it can
not be started again.

The check is very rudimentary and should be replace by actually
checking whether $OSM_USER / OSM_DB / etc. exist.

Signed-off-by: Maximilian Güntner maximilian.guentner@gmail.com
